### PR TITLE
zkp2p-v2-contracts: Initial support for BRL on Mercado Pago

### DIFF
--- a/deployments/verifiers/mercado_pago_reclaim.ts
+++ b/deployments/verifiers/mercado_pago_reclaim.ts
@@ -11,7 +11,8 @@ export const getMercadoReclaimProviderHashes = async (length: number) => {
 export const MERCADO_APPCLIP_PROVIDER_HASHES = []
 
 export const MERCADO_RECLAIM_CURRENCIES: any = [
-  Currency.ARS
+  Currency.ARS,
+  Currency.BRL
 ];
 
 export const MERCADO_RECLAIM_TIMESTAMP_BUFFER = BigNumber.from(30);   // 30 seconds

--- a/utils/protocolUtils.ts
+++ b/utils/protocolUtils.ts
@@ -20,6 +20,7 @@ export const Currency = {
   AED: getKeccak256Hash("AED"),
   ARS: getKeccak256Hash("ARS"),
   AUD: getKeccak256Hash("AUD"),
+  BRL: getKeccak256Hash("BRL"),
   CAD: getKeccak256Hash("CAD"),
   CHF: getKeccak256Hash("CHF"),
   CNY: getKeccak256Hash("CNY"),


### PR DESCRIPTION
For some reason looks like in Brazilian MP they choose negative values for outgoing transaction while Argentina uses a positive value for this.

So we need to work around that by pass the currency to the amount verification function, adjusting for this negative value on BRL payments and for the comman separator we use (and love).