### PR TITLE
OTP Verifier 

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,110 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is the zkp2p-v2-contracts repository for ZK Peer to Peer fiat on/off-ramp smart contracts. It's a Hardhat-based Solidity project that implements payment verification using zero-knowledge proofs and Reclaim Protocol for various payment platforms (Venmo, Revolut, Cashapp, Wise, MercadoPago, Zelle, Paypal, Monzo).
+
+## Essential Commands
+
+### Build and Development
+- `yarn build` - Clean, compile contracts, and generate TypeScript types
+- `yarn compile` - Compile Solidity contracts only
+- `yarn clean` - Remove all build artifacts, coverage data, and generated files
+- `yarn typechain` - Generate TypeScript bindings for contracts
+
+### Testing
+- `yarn test` - Run core tests (libs, verifiers, periphery, escrow)
+- `yarn test:integration` - Run integration tests
+- `yarn test:deploy` - Run deployment tests
+- `yarn test:clean` - Clean build and run tests
+- `yarn test:fast` - Run tests without compilation (for faster iteration)
+
+### Local Development
+- `yarn chain` - Start local Hardhat node without auto-deployment
+- `yarn deploy:localhost` - Deploy contracts to local network
+
+### Network Deployment
+- `yarn deploy:sepolia` - Deploy to Sepolia testnet
+- `yarn deploy:base` - Deploy to Base mainnet and export contract addresses
+- `yarn deploy:base_staging` - Deploy to Base staging and export contract addresses
+
+### Verification
+- `yarn etherscan:sepolia` - Verify contracts on Sepolia Etherscan
+- `yarn etherscan:base` - Verify contracts on Base Etherscan
+- `yarn etherscan:base_staging` - Verify contracts on Base staging Etherscan
+
+## Architecture
+
+### Core Components
+
+**Escrow Contract** (`contracts/Escrow.sol`)
+- Central contract managing deposits, intents, and payment verification
+- Handles multi-currency support and payment processing
+- Uses modular verifier system for different payment platforms
+
+**Payment Verifiers** (`contracts/verifiers/`)
+- Modular verification system for different payment platforms
+- Base classes: `BasePaymentVerifier`, `BaseReclaimVerifier`, `BaseReclaimPaymentVerifier`
+- Platform-specific verifiers: Venmo, Revolut, Cashapp, Wise, MercadoPago, Zelle variants, Paypal, Monzo
+- Each verifier handles platform-specific proof verification and payment validation
+
+**Nullifier Registry** (`contracts/verifiers/nullifierRegistries/`)
+- Prevents double-spending by tracking used nullifiers
+- Shared across verifiers to ensure payment uniqueness
+
+**Utility Libraries** (`contracts/lib/`)
+- `ClaimVerifier` - Core claim verification logic
+- `StringConversionUtils`, `DateParsing` - Data processing utilities
+- `Bytes32ConversionUtils` - Type conversion helpers
+
+### Key Directories
+
+- `contracts/` - Solidity smart contracts
+- `deploy/` - Hardhat deployment scripts numbered sequentially
+- `test/` - Comprehensive test suite organized by component type
+- `utils/` - TypeScript utilities for testing and deployment
+- `deployments/` - Network-specific deployment artifacts and addresses
+- `tasks/` - Custom Hardhat tasks for contract interaction
+
+### Module Aliases
+
+The project uses module aliases defined in package.json:
+- `@utils` maps to `utils/`
+- `@typechain` maps to `typechain/`
+
+### Network Configuration
+
+- **localhost**: Local Hardhat network
+- **sepolia**: Ethereum testnet
+- **base**: Base mainnet
+- **base_staging**: Base staging environment
+
+All networks support contract verification via Etherscan/Basescan APIs.
+
+## Testing Strategy
+
+Tests are organized into categories:
+- `libs/` - Library and utility function tests
+- `verifiers/` - Payment verifier logic tests
+- `periphery/` - Peripheral contract tests (Quoter, etc.)
+- `escrow/` - Core escrow functionality tests
+- `integration/` - End-to-end workflow tests
+- `deploy/` - Deployment script validation tests
+
+## Development Notes
+
+- Uses Solidity 0.8.18 with optimizer enabled (200 runs)
+- TypeChain generates type-safe contract interfaces in `typechain/`
+- Supports both unit testing with Mocha/Chai and integration testing
+- Coverage reports available via `yarn coverage`
+- Gas reporting can be enabled in hardhat.config.ts
+
+## Local Node Setup (from README)
+
+1. Run `yarn install` from the contracts directory
+2. Run `npx hardhat node`
+3. Configure browser wallet with local hardhat network
+4. Import account private key for Account #0 (the deployer)
+5. Run `yarn deploy:localhost`

--- a/contracts/verifiers/OTPVerifier.sol
+++ b/contracts/verifiers/OTPVerifier.sol
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: MIT
+
+import { BasePaymentVerifier } from "./BaseVerifiers/BasePaymentVerifier.sol";
+import { INullifierRegistry } from "./nullifierRegistries/INullifierRegistry.sol";
+import { IPaymentVerifier } from "./interfaces/IPaymentVerifier.sol";
+
+pragma solidity ^0.8.18;
+
+/**
+ * @title OTPVerifier
+ * @notice OTP verifier with deposit-specific hashing to prevent cross-deposit attacks
+ * 
+ * Flow:
+ * 1. Depositor creates deposit with secret hash stored in DepositVerifierData.data
+ * 2. Anyone can signal intent on this deposit (1:1 withdrawal only)
+ * 3. To fulfill intent, user provides the OTP secret 
+ * 4. Contract verifies secret with deposit-specific hashing and releases funds
+ * 
+ * Security:
+ * - Uses deposit-specific hashing: hash(secret, payeeDetails) 
+ * - Prevents cross-deposit attacks where same secret compromises multiple deposits
+ * - No nullifiers needed - escrow prevents double spending via intent removal
+ */
+contract OTPVerifier is IPaymentVerifier, BasePaymentVerifier {
+
+    /* ============ Events ============ */
+    
+    event SecretRevealed(
+        bytes32 indexed secretHash,
+        bytes32 indexed intentHash,
+        address indexed fulfiller
+    );
+
+    /* ============ Constructor ============ */
+    
+    constructor(
+        address _escrow,
+        INullifierRegistry _nullifierRegistry,
+        uint256 _timestampBuffer,
+        bytes32[] memory _currencies
+    ) BasePaymentVerifier(
+        _escrow,
+        _nullifierRegistry,
+        _timestampBuffer,
+        _currencies
+    ) {}
+
+    /* ============ External Functions ============ */
+
+    /**
+     * @notice Verifies OTP using deposit-specific hashing
+     * @param _verifyPaymentData Contains the OTP secret and verification context
+     * @return success Whether verification succeeded
+     * @return intentHash Intent hash extracted from payment proof
+     */
+    function verifyPayment(
+        IPaymentVerifier.VerifyPaymentData calldata _verifyPaymentData
+    ) external override returns (bool success, bytes32 intentHash) {
+        require(msg.sender == escrow, "Only escrow can call");
+
+        // Extract the secret and intent hash from payment proof
+        // Format: [providedSecret(32 bytes)][intentHash(32 bytes)]
+        (bytes32 providedSecret, bytes32 providedIntentHash) = abi.decode(
+            _verifyPaymentData.paymentProof, 
+            (bytes32, bytes32)
+        );
+        
+        // Extract stored secret hash from data field
+        bytes32 storedSecretHash = abi.decode(_verifyPaymentData.data, (bytes32));
+        
+        // Compute deposit-specific hash: hash(secret, payeeDetails)
+        // This prevents cross-deposit attacks where knowing one secret compromises others
+        bytes32 computedHash = keccak256(abi.encodePacked(
+            providedSecret, 
+            _verifyPaymentData.payeeDetails
+        ));
+        
+        require(computedHash == storedSecretHash, "Invalid OTP: secret does not match hash");
+
+        // Verify timing constraint
+        require(
+            block.timestamp >= _verifyPaymentData.intentTimestamp,
+            "Verification cannot happen before intent timestamp"
+        );
+
+        // Return the intent hash that was provided in the payment proof
+        // This follows the same pattern as other verifiers which extract intent hash from proof data
+        intentHash = providedIntentHash;
+
+        emit SecretRevealed(storedSecretHash, intentHash, tx.origin);
+
+        return (true, intentHash);
+    }
+
+    /* ============ Utility Functions ============ */
+
+    /**
+     * @notice Generate deposit-specific secret hash for deposit creation
+     * @param _secret The OTP secret (6-12 word passphrase)
+     * @param _payeeDetails Unique identifier for this deposit
+     * @return Deposit-specific hash that prevents cross-deposit attacks
+     */
+    function generateSecretHash(bytes32 _secret, string memory _payeeDetails) external pure returns (bytes32) {
+        return keccak256(abi.encodePacked(_secret, _payeeDetails));
+    }
+
+    /**
+     * @notice Verify a secret against a deposit-specific hash
+     * @param _secret The secret to verify
+     * @param _payeeDetails The payee details used in original hashing
+     * @param _hash The expected deposit-specific hash
+     * @return Whether the secret matches the hash for this specific deposit
+     */
+    function verifySecret(bytes32 _secret, string memory _payeeDetails, bytes32 _hash) external pure returns (bool) {
+        return keccak256(abi.encodePacked(_secret, _payeeDetails)) == _hash;
+    }
+}

--- a/test/verifiers/otpVerifier.spec.ts
+++ b/test/verifiers/otpVerifier.spec.ts
@@ -1,0 +1,246 @@
+import "module-alias/register";
+
+import { ethers } from "hardhat";
+import { BigNumber } from "ethers";
+
+import { Address } from "@utils/types";
+import { Account } from "@utils/test/types";
+import {
+  Escrow,
+  USDCMock,
+  NullifierRegistry,
+  OTPVerifier
+} from "@utils/contracts";
+import DeployHelper from "@utils/deploys";
+
+import {
+  getWaffleExpect,
+  getAccounts,
+  addSnapshotBeforeRestoreAfterEach
+} from "@utils/test/index";
+import { ether, usdc, Blockchain } from "@utils/common";
+import { ZERO, ONE, ADDRESS_ZERO } from "@utils/constants";
+import { Currency, calculateIntentHash } from "@utils/protocolUtils";
+
+const expect = getWaffleExpect();
+
+const blockchain = new Blockchain(ethers.provider);
+
+describe("OTPVerifier - Simple Integration Test", () => {
+  let owner: Account;
+  let depositor: Account;
+  let withdrawer: Account;
+
+  let escrow: Escrow;
+  let usdcToken: USDCMock;
+  let nullifierRegistry: NullifierRegistry;
+  let otpVerifier: OTPVerifier;
+
+  let deployer: DeployHelper;
+
+  // Test parameters
+  const depositAmount = usdc(100); // 100 USDC
+  const secret = ethers.utils.formatBytes32String("horse battery staple magic");
+  const payeeDetails = "alice-deposit-123";
+
+  addSnapshotBeforeRestoreAfterEach();
+
+  beforeEach(async () => {
+    [owner, depositor, withdrawer] = await getAccounts();
+    deployer = new DeployHelper(owner.wallet);
+
+    // Deploy USDC mock and mint tokens
+    usdcToken = await deployer.deployUSDCMock(ether(1000000), "USDC", "USDC");
+    await usdcToken.transfer(depositor.address, usdc(1000));
+
+    // Deploy Escrow
+    escrow = await deployer.deployEscrow(
+      owner.address,
+      BigNumber.from(86400), // 1 day intent expiration
+      ether(0.01),           // 1% sustainability fee
+      owner.address,         // fee recipient
+      ONE                    // chain ID
+    );
+
+    // Deploy Nullifier Registry
+    nullifierRegistry = await deployer.deployNullifierRegistry();
+
+    // Deploy OTP Verifier
+    otpVerifier = await deployer.deployOTPVerifier(
+      escrow.address,
+      nullifierRegistry.address,
+      BigNumber.from(300), // 5 min timestamp buffer
+      [Currency.USD]       // supported currencies
+    );
+
+    // Add OTP verifier as whitelisted payment verifier
+    await escrow.addWhitelistedPaymentVerifier(otpVerifier.address, ZERO);
+
+    console.log("\n=== Contract Addresses ===");
+    console.log("Escrow:", escrow.address);
+    console.log("USDC:", usdcToken.address);
+    console.log("OTPVerifier:", otpVerifier.address);
+    console.log("NullifierRegistry:", nullifierRegistry.address);
+  });
+
+  describe("Full OTP Flow", () => {
+    it("Should complete entire OTP deposit and withdrawal flow", async () => {
+      console.log("\n=== Step 1: Generate OTP Secret Hash ===");
+      
+      // Generate secret hash using deposit-specific hashing
+      const secretHash = await otpVerifier.generateSecretHash(secret, payeeDetails);
+      console.log("Secret:", ethers.utils.parseBytes32String(secret));
+      console.log("Payee Details:", payeeDetails);  
+      console.log("Secret Hash:", secretHash);
+
+      console.log("\n=== Step 2: Create Deposit ===");
+      
+      // Approve USDC transfer
+      await usdcToken.connect(depositor.wallet).approve(escrow.address, depositAmount);
+
+      // Create deposit with OTP verifier
+      await escrow.connect(depositor.wallet).createDeposit(
+        usdcToken.address,
+        depositAmount,
+        { min: depositAmount, max: depositAmount }, // Force full withdrawal
+        [otpVerifier.address], // verifiers
+        [{
+          intentGatingService: ADDRESS_ZERO,
+          payeeDetails: payeeDetails,
+          data: ethers.utils.defaultAbiCoder.encode(["bytes32"], [secretHash])
+        }], // verifier data  
+        [[{ code: Currency.USD, conversionRate: ether(1) }]] // currencies
+      );
+
+      const depositId = 0;
+      console.log("✓ Deposit created with ID:", depositId);
+
+      // Verify deposit state
+      const deposit = await escrow.deposits(depositId);
+      expect(deposit.amount).to.equal(depositAmount);
+      expect(deposit.remainingDeposits).to.equal(depositAmount);
+      console.log("✓ Deposit amount:", ethers.utils.formatUnits(deposit.amount, 6), "USDC");
+
+      console.log("\n=== Step 3: Signal Intent ===");
+      
+      // Signal intent to withdraw full amount
+      const signalIntentTx = await escrow.connect(withdrawer.wallet).signalIntent(
+        depositId,
+        depositAmount,
+        withdrawer.address,
+        otpVerifier.address,
+        Currency.USD,
+        "0x" // empty gating service signature since we use ADDRESS_ZERO
+      );
+
+      // Get timestamp from the block where the intent was signaled
+      const signalIntentReceipt = await signalIntentTx.wait();
+      const signalBlock = await ethers.provider.getBlock(signalIntentReceipt.blockNumber);
+      const signalTimestamp = BigNumber.from(signalBlock.timestamp);
+      
+      const calculatedIntentHash = calculateIntentHash(
+        withdrawer.address,
+        otpVerifier.address, 
+        BigNumber.from(depositId),
+        signalTimestamp
+      );
+      
+      // Get the actual intent hash stored in the escrow
+      const actualIntentHash = await escrow.accountIntent(withdrawer.address);
+      
+      console.log("✓ Intent signaled");
+      console.log("  - Calculated intent hash:", calculatedIntentHash);
+      console.log("  - Actual intent hash:    ", actualIntentHash);
+      console.log("  - Intent hashes match:   ", calculatedIntentHash === actualIntentHash);
+      
+      const intentHash = actualIntentHash; // Use the actual hash from the escrow
+
+      console.log("\n=== Step 4: Fulfill Intent (Provide OTP) ===");
+
+      // Encode the secret and intent hash as payment proof
+      // Format: [secret, intentHash] - following the same pattern as other verifiers
+      const paymentProof = ethers.utils.defaultAbiCoder.encode(
+        ["bytes32", "bytes32"], 
+        [secret, intentHash]
+      );
+
+      // Fulfill intent by providing the OTP secret and intent hash
+      await escrow.connect(withdrawer.wallet).fulfillIntent(paymentProof, intentHash);
+
+      console.log("✓ Intent fulfilled with OTP secret!");
+
+      console.log("\n=== Step 5: Verify Final State ===");
+
+      // Check that withdrawer received the tokens
+      const withdrawerBalance = await usdcToken.balanceOf(withdrawer.address);
+      expect(withdrawerBalance).to.be.gt(ZERO); // Should have received tokens minus fees
+      console.log("✓ Withdrawer received:", ethers.utils.formatUnits(withdrawerBalance, 6), "USDC");
+
+      // Check that deposit is consumed
+      const finalDeposit = await escrow.deposits(depositId);
+      expect(finalDeposit.remainingDeposits).to.equal(ZERO);
+      console.log("✓ Deposit fully consumed");
+
+      console.log("\n=== ✅ OTP Flow Complete! ===");
+      console.log("Summary:");
+      console.log("- Depositor locked 100 USDC with OTP secret");
+      console.log("- Withdrawer provided correct OTP and received USDC");
+      console.log("- No cross-deposit attack possible (deposit-specific hashing)");
+      console.log("- No nullifiers used (escrow handles double-spending)");
+    });
+
+    it("Should reject incorrect OTP secret", async () => {
+      console.log("\n=== Testing Incorrect OTP ===");
+
+      // Generate secret hash
+      const secretHash = await otpVerifier.generateSecretHash(secret, payeeDetails);
+
+      // Create deposit  
+      await usdcToken.connect(depositor.wallet).approve(escrow.address, depositAmount);
+      await escrow.connect(depositor.wallet).createDeposit(
+        usdcToken.address,
+        depositAmount,
+        { min: depositAmount, max: depositAmount },
+        [otpVerifier.address],
+        [{
+          intentGatingService: ADDRESS_ZERO,
+          payeeDetails: payeeDetails,
+          data: ethers.utils.defaultAbiCoder.encode(["bytes32"], [secretHash])
+        }],
+        [[{ code: Currency.USD, conversionRate: ether(1) }]]
+      );
+
+      // Signal intent
+      const signalIntentTx2 = await escrow.connect(withdrawer.wallet).signalIntent(
+        0, depositAmount, withdrawer.address, 
+        otpVerifier.address, Currency.USD, "0x"
+      );
+
+      // Calculate intent hash properly
+      const signalIntentReceipt2 = await signalIntentTx2.wait();
+      const signalBlock2 = await ethers.provider.getBlock(signalIntentReceipt2.blockNumber);
+      const signalTimestamp2 = BigNumber.from(signalBlock2.timestamp);
+      
+      const intentHash = calculateIntentHash(
+        withdrawer.address,
+        otpVerifier.address,
+        ZERO,
+        signalTimestamp2
+      );
+
+      // Try to fulfill with WRONG secret
+      const wrongSecret = ethers.utils.formatBytes32String("wrong secret");
+      const wrongPaymentProof = ethers.utils.defaultAbiCoder.encode(
+        ["bytes32", "bytes32"], 
+        [wrongSecret, intentHash]
+      );
+
+      // Should fail
+      await expect(
+        escrow.connect(withdrawer.wallet).fulfillIntent(wrongPaymentProof, intentHash)
+      ).to.be.revertedWith("Invalid OTP: secret does not match hash");
+
+      console.log("✓ Correctly rejected wrong OTP secret");
+    });
+  });
+});

--- a/utils/contracts.ts
+++ b/utils/contracts.ts
@@ -20,6 +20,7 @@ export {
   ZelleBaseVerifier,
   ZelleBoAReclaimVerifier,
   ZelleCitiReclaimVerifier,
-  ZelleChaseReclaimVerifier
+  ZelleChaseReclaimVerifier,
+  OTPVerifier
 } from "../typechain";
 export { IEscrow } from "../typechain/contracts/Escrow";

--- a/utils/deploys.ts
+++ b/utils/deploys.ts
@@ -26,7 +26,8 @@ import {
   ZelleCitiReclaimVerifier,
   ZelleChaseReclaimVerifier,
   ZelleBaseVerifier,
-  BaseReclaimVerifier
+  BaseReclaimVerifier,
+  OTPVerifier
 } from "./contracts";
 import {
   StringConversionUtilsMock__factory,
@@ -50,6 +51,7 @@ import { MercadoPagoReclaimVerifier__factory } from "../typechain/factories/cont
 import { ZelleBoAReclaimVerifier__factory } from "../typechain/factories/contracts/verifiers/ZelleVerifiers";
 import { ZelleCitiReclaimVerifier__factory } from "../typechain/factories/contracts/verifiers/ZelleVerifiers";
 import { ZelleChaseReclaimVerifier__factory } from "../typechain/factories/contracts/verifiers/ZelleVerifiers";
+import { OTPVerifier__factory } from "../typechain/factories/contracts/verifiers";
 
 export default class DeployHelper {
   private _deployerSigner: Signer;
@@ -295,6 +297,20 @@ export default class DeployHelper {
 
   public async deployNullifierRegistry(): Promise<NullifierRegistry> {
     return await new NullifierRegistry__factory(this._deployerSigner).deploy();
+  }
+
+  public async deployOTPVerifier(
+    escrow: Address,
+    nullifierRegistry: Address,
+    timestampBuffer: BigNumber,
+    currencies: string[]
+  ): Promise<OTPVerifier> {
+    return await new OTPVerifier__factory(this._deployerSigner).deploy(
+      escrow,
+      nullifierRegistry,
+      timestampBuffer,
+      currencies
+    );
   }
 
   public async deployManagedKeyHashAdapterV2(keyHashes: string[]): Promise<ManagedKeyHashAdapterV2> {


### PR DESCRIPTION
### Summary

A payment verifier that releases escrow based on knowledge of a pre-shared secret. Users prove payment by providing the correct OTP/secret that matches a pre-committed hash.

### Notes 

- **Word-based secrets:** Uses human-readable passphrases converted to bytes32
`const secret = ethers.utils.formatBytes32String("horse battery staple magic");`

- **Deposit-specific hashing**: Prevents cross-deposit attacks by binding secrets to specific deposits
  `hash = keccak256(abi.encodePacked(secret, payeeDetails))`

 - Each deposit gets a unique hash even with the same secret due to payeeDetails salt
 - Attacker knowing one secret cannot compromise other deposits
 - No nullifiers needed - escrow prevents double-spending via intent removal

### Use Case
Suitable for cash payouts where users can establish a secure side-channel to share word-based secrets after payment completion, trading external payment verification for simplicity and human-readable secrets.
