### PR TITLE
Feat: Emit netAdditionalAmount in DepositFundsAdded

### DIFF
--- a/contracts/Escrow.sol
+++ b/contracts/Escrow.sol
@@ -229,7 +229,7 @@ contract Escrow is Ownable, Pausable, IEscrow {
         deposit.remainingDeposits += netAdditionalAmount;
         deposit.reservedMakerFees += totalFees;
         
-        emit DepositFundsAdded(_depositId, msg.sender, _amount);
+        emit DepositFundsAdded(_depositId, msg.sender, _amount, netAdditionalAmount);
         
         // Interactions
         deposit.token.safeTransferFrom(msg.sender, address(this), _amount);

--- a/contracts/interfaces/IEscrow.sol
+++ b/contracts/interfaces/IEscrow.sol
@@ -78,7 +78,7 @@ interface IEscrow {
     event DepositCurrencyAdded(uint256 indexed depositId, bytes32 indexed paymentMethod, bytes32 indexed currency, uint256 minConversionRate);
     event DepositCurrencyRemoved(uint256 indexed depositId, bytes32 indexed paymentMethod, bytes32 indexed currencyCode);        
 
-    event DepositFundsAdded(uint256 indexed depositId, address indexed depositor, uint256 amount);
+    event DepositFundsAdded(uint256 indexed depositId, address indexed depositor, uint256 amount, uint256 netAdditionalAmount);
     event DepositWithdrawn(uint256 indexed depositId, address indexed depositor, uint256 amount, bool acceptingIntents);
     event DepositClosed(uint256 depositId, address depositor);
 

--- a/package.json
+++ b/package.json
@@ -77,4 +77,4 @@
     "@typechain": "typechain"
   },
   "packageManager": "yarn@4.9.1"
-  }
+}

--- a/test/escrow/escrow.spec.ts
+++ b/test/escrow/escrow.spec.ts
@@ -881,10 +881,12 @@ describe("Escrow", () => {
     });
 
     it("should emit a DepositFundsAdded event", async () => {
+      const netAdditionalAmount = subjectAmount;
       await expect(subject()).to.emit(ramp, "DepositFundsAdded").withArgs(
         subjectDepositId,
         offRamper.address,
-        subjectAmount
+        subjectAmount,
+        netAdditionalAmount
       );
     });
 
@@ -1084,6 +1086,17 @@ describe("Escrow", () => {
         expect(rampPostBalance.sub(rampPreBalance)).to.eq(subjectAmount);
       });
 
+      it("should emit a DepositFundsAdded event", async () => {
+        const expectedReferrerFees = subjectAmount.mul(referrerFee).div(ether(1)); // 2% of 50 = 1 USDC
+        const netAdditionalAmount = subjectAmount - expectedReferrerFees;
+        await expect(subject()).to.emit(ramp, "DepositFundsAdded").withArgs(
+          subjectDepositId,
+          offRamper.address,
+          subjectAmount,
+          netAdditionalAmount
+        );
+      });
+
       describe("when both maker and referrer fees are enabled", async () => {
         let makerFeeRate: BigNumber;
 
@@ -1140,6 +1153,19 @@ describe("Escrow", () => {
           const wouldBeWithNewRate = subjectAmount.mul(newGlobalMakerFee).div(ether(1));
           const wouldBeTotalWithNewRate = wouldBeWithNewRate.add(expectedReferrerFees);
           expect(deposit.reservedMakerFees).to.not.eq(initialDeposit.reservedMakerFees.add(wouldBeTotalWithNewRate));
+        });
+
+        it("should emit a DepositFundsAdded event", async () => {
+          const expectedMakerFees = subjectAmount.mul(makerFeeRate).div(ether(1)); // 1% of 50 = 0.5 USDC
+          const expectedReferrerFees = subjectAmount.mul(referrerFee).div(ether(1)); // 2% of 50 = 1 USDC
+          const totalFees = expectedMakerFees.add(expectedReferrerFees); // 1.5 USDC total
+          const netAdditionalAmount = subjectAmount - totalFees;
+          await expect(subject()).to.emit(ramp, "DepositFundsAdded").withArgs(
+            subjectDepositId,
+            offRamper.address,
+            subjectAmount,
+            netAdditionalAmount
+          );
         });
       });
 


### PR DESCRIPTION
Makes it easier for indexer to know how much to bump availableLiquidity/remainingDeposits by.