### PR TITLE
feat(indexer): Emit netDepositAmount in DepositReceived

### DIFF
--- a/contracts/Escrow.sol
+++ b/contracts/Escrow.sol
@@ -183,8 +183,8 @@ contract Escrow is Ownable, Pausable, IEscrow {
             depositId, 
             msg.sender, 
             _params.token,
-            netDepositAmount,
             _params.amount,
+            netDepositAmount,
             _params.intentAmountRange, 
             _params.delegate, 
             _params.intentGuardian

--- a/contracts/Escrow.sol
+++ b/contracts/Escrow.sol
@@ -182,8 +182,9 @@ contract Escrow is Ownable, Pausable, IEscrow {
         emit DepositReceived(
             depositId, 
             msg.sender, 
-            _params.token, 
-            _params.amount, 
+            _params.token,
+            netDepositAmount,
+            _params.amount,
             _params.intentAmountRange, 
             _params.delegate, 
             _params.intentGuardian

--- a/contracts/interfaces/IEscrow.sol
+++ b/contracts/interfaces/IEscrow.sol
@@ -70,7 +70,7 @@ interface IEscrow {
 
     /* ============ Events ============ */
 
-    event DepositReceived(uint256 indexed depositId, address indexed depositor, IERC20 indexed token, uint256 amount, Range intentAmountRange, address delegate, address intentGuardian);
+    event DepositReceived(uint256 indexed depositId, address indexed depositor, IERC20 indexed token, uint256 amount, uint256 netDepositAmount, Range intentAmountRange, address delegate, address intentGuardian);
 
     event DepositPaymentMethodAdded(uint256 indexed depositId, bytes32 indexed paymentMethod, bytes32 indexed payeeDetails, address intentGatingService);
     event DepositPaymentMethodRemoved(uint256 indexed depositId, bytes32 indexed paymentMethod);

--- a/test/escrow/escrow.spec.ts
+++ b/test/escrow/escrow.spec.ts
@@ -455,12 +455,13 @@ describe("Escrow", () => {
       });
 
       it("should emit a DepositReceived event with the correct net deposit amount", async () => {
-        const expectedNetDepositAmount = subjectAmount.mul(ether(0.98));
+        const depositAmount = usdc(1000);
+        const expectedNetDepositAmount = depositAmount.mul(ether(0.98));
         await expect(subject()).to.emit(ramp, "DepositReceived").withArgs(
           ZERO, // depositId starts at 0
           offRamper.address,
           subjectToken,
-          subjectAmount,
+          depositAmount,
           expectedNetDepositAmount,
           subjectIntentAmountRange,
           subjectDelegate,

--- a/test/escrow/escrow.spec.ts
+++ b/test/escrow/escrow.spec.ts
@@ -326,6 +326,7 @@ describe("Escrow", () => {
         offRamper.address,
         subjectToken,
         subjectAmount,
+        subjectAmount,
         subjectIntentAmountRange,
         subjectDelegate,
         subjectIntentGuardian
@@ -451,6 +452,20 @@ describe("Escrow", () => {
         const deposit = await ramp.getDeposit(ZERO);
         expect(deposit.referrer).to.eq(referrer.address);
         expect(deposit.referrerFee).to.eq(ether(0.02));
+      });
+
+      it("should emit a DepositReceived event with the correct net deposit amount", async () => {
+        const expectedNetDepositAmount = subjectAmount.mul(ether(0.98));
+        await expect(subject()).to.emit(ramp, "DepositReceived").withArgs(
+          ZERO, // depositId starts at 0
+          offRamper.address,
+          subjectToken,
+          subjectAmount,
+          expectedNetDepositAmount,
+          subjectIntentAmountRange,
+          subjectDelegate,
+          subjectIntentGuardian
+        );
       });
 
       it("should transfer the tokens to the Escrow contract", async () => {

--- a/test/escrow/escrow.spec.ts
+++ b/test/escrow/escrow.spec.ts
@@ -423,7 +423,7 @@ describe("Escrow", () => {
         subjectDepositParams = {
           token: usdcToken.address,
           amount: usdc(1000),
-          intentAmountRange: { min: usdc(10), max: usdc(100) },
+          intentAmountRange: { min: subjectIntentAmountRange.min, max: subjectIntentAmountRange.max },
           paymentMethods: [venmoPaymentMethodHash],
           paymentMethodData: [{
             intentGatingService: gatingService.address,
@@ -456,13 +456,13 @@ describe("Escrow", () => {
 
       it("should emit a DepositReceived event with the correct net deposit amount", async () => {
         const depositAmount = usdc(1000);
-        const expectedNetDepositAmount = depositAmount.mul(ether(0.98));
+        const expectedNetDepositAmount = usdc(980); // 2% referrer fee
         await expect(subject()).to.emit(ramp, "DepositReceived").withArgs(
           ZERO, // depositId starts at 0
           offRamper.address,
           subjectToken,
           depositAmount,
-          expectedNetDepositAmount,
+          expectedNetDepositAmount.toString(),
           subjectIntentAmountRange,
           subjectDelegate,
           subjectIntentGuardian


### PR DESCRIPTION
Emit `netDepositAmount` for easier reading of `remainingDeposits` and `availableLiquidity` to calculate quotes